### PR TITLE
Update clan imports for gerbil-utils v0.2.

### DIFF
--- a/server.ss
+++ b/server.ss
@@ -1,7 +1,7 @@
 ;; -*- Gerbil -*-
 package: ftw
 (export #t)
-(import :clan/utils/base :std/net/httpd :std/net/address
+(import :clan/base :std/net/httpd :std/net/address
         :std/generic)
 
 (defclass ftw-server 

--- a/server/handle-file.ss
+++ b/server/handle-file.ss
@@ -3,7 +3,7 @@ package: ftw/server
 (export static-file-handler)
 
 (import :ftw/http-status-code :ftw/file
-        :clan/utils/base
+        :clan/base
         :gerbil/gambit/bytes :gerbil/gambit/os
         :std/net/httpd :std/generic :std/sugar :std/pregexp :std/srfi/1)
 

--- a/server/reply.ss
+++ b/server/reply.ss
@@ -1,7 +1,7 @@
 (export #t)
 (import :ftw/http-status-code
 	:std/generic
-	:clan/utils/base)
+	:clan/base)
 
 (defclass reply
   (content-type

--- a/test/server/handle-file.ss
+++ b/test/server/handle-file.ss
@@ -2,7 +2,7 @@
 package: test/ftw/server
 (export #t)
 (import :ftw/server :ftw/server/handle-file
-        :clan/utils/base :std/net/request :std/generic)
+        :clan/base :std/net/request :std/generic)
 
 (defclass (test-handle-file-server ftw-server)
   (not-found))

--- a/timestamp.ss
+++ b/timestamp.ss
@@ -1,10 +1,10 @@
 ;; -*- Gerbil -*-
 
-(import :clan/utils/timestamp
+(import :clan/timestamp
         :std/srfi/19
         (rename-in :gerbil/gambit/os (time? time??)))
 
-(export #t (import: :clan/utils/timestamp))
+(export #t (import: :clan/timestamp))
 
 (def rfc-1123-format-string "~a, ~d ~b ~Y ~H:~M:~S GMT")
 


### PR DESCRIPTION
Change all clan imports from ':clan/utils/xyz' to ':clan/xyz' to match
updated package naming for gerbil-utils v0.2.

Reference github.com/fare/gerbil-utils
[fca4eb1a65159af070af4c8d885560017be9bc63].